### PR TITLE
chore(ci): publish to gemfury DIA-46120

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
-      - run: npm publish
+      - run: npm pack | { read file_name; curl -F "package=@$file_name" "https://$NPM_TOKEN@push.fury.io/dialogue/"; }
 
 workflows:
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
-      - run:  npm publish --registry https://npm-proxy.fury.io/dialogue/
+      - run:  cd ~/ckeditor5/packages/ckeditor5-build-balloon-block && npm publish --registry https://npm-proxy.fury.io/dialogue/
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 jobs:
   publish:
+    working_directory: ~/ckeditor5
     docker:
       - image: circleci/node:14
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 jobs:
   build:
-    working_directory: ~/ckeditor5
+    working_directory: ~/ckeditor5/packages/ckeditor5-build-balloon-block
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
-      - run:  cd ~/ckeditor5/packages/ckeditor5-build-balloon-block && npm publish --registry https://npm-proxy.fury.io/dialogue/
+      - run:  cd ~/ckeditor5/packages/ckeditor5-build-balloon-block && npm publish --registry https://$NPM_TOKEN@push.fury.io/dialogue/
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
-      - run:  npm publish --registry https://$GEMFURY_TOKEN@push.fury.io/dialogue/
+      - run:  npm publish --registry https://npm-proxy.fury.io/dialogue/
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ jobs:
   publish:
     working_directory: ~/ckeditor5/packages/ckeditor5-build-balloon-block
     docker:
-      - image: circleci/node:14
+      - image: circleci/node:16
     steps:
       - checkout
       - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
       - run:  cd ~/ckeditor5/packages/ckeditor5-build-balloon-block && npm publish --registry https://$NPM_TOKEN@push.fury.io/dialogue/
 
 workflows:
-  build:
+  publish:
     jobs:
       - publish:
 #          filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ jobs:
   publish:
     working_directory: ~/ckeditor5/packages/ckeditor5-build-balloon-block
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:14
     steps:
       - checkout
       - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
-      - run:  cd ~/ckeditor5/packages/ckeditor5-build-balloon-block && npm publish --registry https://$NPM_TOKEN@push.fury.io/dialogue/
+      - run: npm publish --registry https://$NPM_TOKEN@push.fury.io/dialogue/
 
 workflows:
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ workflows:
   publish:
     jobs:
       - publish:
-#          filters:
-#            tags:
-#              only: /.*/
+          filters:
+            tags:
+              only: /.*/
           context:
             - gemfury-upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
-      - run: npm publish --registry https://$NPM_TOKEN@push.fury.io/dialogue/
+      - run: npm publish
 
 workflows:
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
-      - run: npm pack | { read file_name; curl -F "package=@$file_name" "https://$NPM_TOKEN@push.fury.io/dialogue/"; }
+      - run: npm pack | { read file_name; curl -F "package=@$file_name" "https://$GEMFURY_TOKEN@push.fury.io/dialogue/"; }
 
 workflows:
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,46 @@
 version: 2.1
-
-
 jobs:
   build:
+    working_directory: ~/ckeditor5
     docker:
-      - image: circleci/node:14
+      - image: circleci/node:10
     steps:
       - checkout
-      - run:
-          name: Create distribution
+
+      - restore_cache:
+          keys:
+            - ckeditor5-{{ .Branch }}-{{ checksum "package.json" }}
+            - ckeditor5-{{ .Branch }}-
+            - ckeditor5-
+
+      - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
+
+      - run: npm ci
+
+      - save_cache:
+          key: v1-basics-{{ .Branch }}-{{ checksum "package.json" }}
+          paths:
+            - ~/.npm
+
+      - run: npm run lint
+
+      # - run: npm run test -- --coverage
+
+      - run: npm run build
+
+      - deploy:
+          name: Publish to NPM
           command: |
-            printf "registry=https://tictrac.jfrog.io/artifactory/api/npm/npm/\nemail=developer@tictrac.com\nalways-auth=true\n_auth=$JFROG_AUTH_ENC" > ~/.npmrc
-            cd packages/ckeditor5-build-balloon-block
-            npm publish --registry https://tictrac.jfrog.io/artifactory/api/npm/npm/
-      - slack/status
+            if [[ $CIRCLE_TAG ]]; then
+              npm pack | { read file_name; curl -F "package=@$file_name" "https://$GEMFURY_TOKEN@push.fury.io/dialogue/"; }
+            fi
 
 workflows:
-  tictrac:
+  build:
     jobs:
       - build:
-          name: Docker build
-          context: Infrastructure
           filters:
             tags:
-              only: /^.*/
-            branches:
               only: /.*/
-
-orbs:
-  slack: circleci/slack@3.4.2
+          context:
+            - gemfury-upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,44 +1,18 @@
 version: 2.1
 jobs:
-  build:
+  publish:
     working_directory: ~/ckeditor5/packages/ckeditor5-build-balloon-block
     docker:
       - image: circleci/node:14
     steps:
       - checkout
-
-      - restore_cache:
-          keys:
-            - ckeditor5-{{ .Branch }}-{{ checksum "package.json" }}
-            - ckeditor5-{{ .Branch }}-
-            - ckeditor5-
-
       - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
-
-      - run: npm ci
-
-      - save_cache:
-          key: v1-basics-{{ .Branch }}-{{ checksum "package.json" }}
-          paths:
-            - ~/.npm
-
-      - run: npm run lint
-
-      # - run: npm run test -- --coverage
-
-      - run: npm run build
-
-      - deploy:
-          name: Publish to NPM
-          command: |
-            if [[ $CIRCLE_TAG ]]; then
-              npm pack | { read file_name; curl -F "package=@$file_name" "https://$GEMFURY_TOKEN@push.fury.io/dialogue/"; }
-            fi
+      - run:  npm publish --registry https://$GEMFURY_TOKEN@push.fury.io/dialogue/
 
 workflows:
   build:
     jobs:
-      - build:
+      - publish:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 jobs:
   publish:
-    working_directory: ~/ckeditor5/packages/ckeditor5-build-balloon-block
     docker:
       - image: circleci/node:14
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,43 @@
 version: 2.1
 jobs:
-  publish:
+  build:
     working_directory: ~/ckeditor5/packages/ckeditor5-build-balloon-block
     docker:
       - image: circleci/node:14
     steps:
       - checkout
-      - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
-      - run:  cd ~/ckeditor5/packages/ckeditor5-build-balloon-block && npm publish --registry https://$NPM_TOKEN@push.fury.io/dialogue/
 
+      - restore_cache:
+          keys:
+            - ckeditor5-{{ .Branch }}-{{ checksum "package.json" }}
+            - ckeditor5-{{ .Branch }}-
+            - ckeditor5-
+
+      - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$NPM_TOKEN >> ~/.npmrc
+
+      - run: npm ci
+
+      - save_cache:
+          key: ckeditor5-{{ .Branch }}-{{ checksum "package.json" }}
+          paths:
+            - ~/.npm
+
+      - run: npm run lint
+
+      # - run: npm run test -- --coverage
+
+      - run: npm run build
+
+      - deploy:
+          name: Publish to NPM
+          command: |
+            if [[ $CIRCLE_TAG ]]; then
+              npm pack | { read file_name; curl -F "package=@$file_name" "https://$NPM_TOKEN@push.fury.io/dialogue/"; }
+            fi
 workflows:
   build:
     jobs:
-      - publish:
+      - build:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ jobs:
           paths:
             - ~/.npm
 
-      - run: npm run lint
+#      - run: npm run lint
 
       # - run: npm run test -- --coverage
 
-      - run: npm run build
+#      - run: npm run build
 
       - deploy:
           name: Publish to NPM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ workflows:
   build:
     jobs:
       - publish:
-          filters:
-            tags:
-              only: /.*/
+#          filters:
+#            tags:
+#              only: /.*/
           context:
             - gemfury-upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,43 +1,18 @@
 version: 2.1
 jobs:
-  build:
+  publish:
     working_directory: ~/ckeditor5/packages/ckeditor5-build-balloon-block
     docker:
       - image: circleci/node:14
     steps:
       - checkout
+      - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
+      - run:  cd ~/ckeditor5/packages/ckeditor5-build-balloon-block && npm publish --registry https://$NPM_TOKEN@push.fury.io/dialogue/
 
-      - restore_cache:
-          keys:
-            - ckeditor5-{{ .Branch }}-{{ checksum "package.json" }}
-            - ckeditor5-{{ .Branch }}-
-            - ckeditor5-
-
-      - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$NPM_TOKEN >> ~/.npmrc
-
-      - run: npm ci
-
-      - save_cache:
-          key: ckeditor5-{{ .Branch }}-{{ checksum "package.json" }}
-          paths:
-            - ~/.npm
-
-#      - run: npm run lint
-
-      # - run: npm run test -- --coverage
-
-#      - run: npm run build
-
-      - deploy:
-          name: Publish to NPM
-          command: |
-            if [[ $CIRCLE_TAG ]]; then
-              npm pack | { read file_name; curl -F "package=@$file_name" "https://$NPM_TOKEN@push.fury.io/dialogue/"; }
-            fi
 workflows:
   build:
     jobs:
-      - build:
+      - publish:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: echo //npm-proxy.fury.io/dialogue/:_authToken=$GEMFURY_TOKEN >> ~/.npmrc
-      - run: npm pack | { read file_name; curl -F "package=@$file_name" "https://$GEMFURY_TOKEN@push.fury.io/dialogue/"; }
+      - run: cd ~/ckeditor5/packages/ckeditor5-build-balloon-block && npm pack | { read file_name; curl -F "package=@$file_name" "https://$GEMFURY_TOKEN@push.fury.io/dialogue/"; }
 
 workflows:
   publish:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3158,7 +3158,7 @@
         "node": ">=10"
       }
     },
-    "node_modules/@tictrac/ckeditor5-build-balloon-block": {
+    "node_modules/@dialogue/ckeditor5-build-balloon-block": {
       "resolved": "packages/ckeditor5-build-balloon-block",
       "link": true
     },
@@ -30472,7 +30472,7 @@
       }
     },
     "packages/ckeditor5-build-balloon-block": {
-      "name": "@tictrac/ckeditor5-build-balloon-block",
+      "name": "@dialogue/ckeditor5-build-balloon-block",
       "version": "31.0.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -35630,7 +35630,7 @@
         "defer-to-connect": "^2.0.0"
       }
     },
-    "@tictrac/ckeditor5-build-balloon-block": {
+    "@dialogue/ckeditor5-build-balloon-block": {
       "version": "file:packages/ckeditor5-build-balloon-block",
       "requires": {
         "@ckeditor/ckeditor5-adapter-ckfinder": "^31.0.0",
@@ -38474,7 +38474,7 @@
         "@ckeditor/ckeditor5-watchdog": "file:packages/ckeditor5-watchdog",
         "@ckeditor/ckeditor5-widget": "file:packages/ckeditor5-widget",
         "@ckeditor/ckeditor5-word-count": "file:packages/ckeditor5-word-count",
-        "@tictrac/ckeditor5-build-balloon-block": "file:packages/ckeditor5-build-balloon-block",
+        "@dialogue/ckeditor5-build-balloon-block": "file:packages/ckeditor5-build-balloon-block",
         "@webspellchecker/wproofreader-ckeditor5": "^2.0.1",
         "@wiris/mathtype-ckeditor5": "^7.24.0",
         "babel-standalone": "^6.26.0",
@@ -41955,7 +41955,7 @@
             "defer-to-connect": "^2.0.0"
           }
         },
-        "@tictrac/ckeditor5-build-balloon-block": {
+        "@dialogue/ckeditor5-build-balloon-block": {
           "version": "file:packages/ckeditor5-build-balloon-block",
           "requires": {
             "@ckeditor/ckeditor5-adapter-ckfinder": "^31.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "ckeditor5",
   "version": "31.0.0",
   "description": "The development environment of CKEditor 5 – the best browser-based rich text editor.",
-  "private": true,
   "keywords": [
     "ckeditor",
     "ckeditor5",

--- a/packages/ckeditor5-build-balloon-block/package-lock.json
+++ b/packages/ckeditor5-build-balloon-block/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@tictrac/ckeditor5-build-balloon-block",
+  "name": "@dialogue/ckeditor5-build-balloon-block",
   "version": "31.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@tictrac/ckeditor5-build-balloon-block",
+      "name": "@dialogue/ckeditor5-build-balloon-block",
       "version": "31.0.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {

--- a/packages/ckeditor5-build-balloon-block/package.json
+++ b/packages/ckeditor5-build-balloon-block/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tictrac/ckeditor5-build-balloon-block",
+  "name": "@dialogue/ckeditor5-build-balloon-block",
   "version": "31.0.0",
   "description": "The balloon editor build of CKEditor 5 with a block toolbar – the best browser-based rich text editor.",
   "keywords": [
@@ -61,7 +61,7 @@
     "node": ">=12.0.0",
     "npm": ">=5.7.1"
   },
-  "author": "developer@tictrac.com",
+  "author": "developer@dialogue.com",
   "license": "GPL-2.0-or-later",
   "homepage": "https://github.com/Tictrac/ckeditor5",
   "repository": {


### PR DESCRIPTION
## Description
Publish `@dialogue/ckeditor5-build-balloon-block` in gemfury as this is a dependency of community-hub-web.

This lib is a 2 years old fork from the ckeditor5 lib and should be deprecated.

## Validation
<img width="900" alt="image" src="https://user-images.githubusercontent.com/4623908/188942738-578a4540-6c53-4337-8fce-c602905a5588.png">
