### PR TITLE
chore: use local npmrc - DIA-59721

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: dialogue/node@1.0.0
+  node: dialogue/node@1.4.4
 
 aliases:
   - &executor

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,6 @@ yarn.lock
 # Ignore `mrgit.json` this file contains info about external repositories.
 mrgit.json
 
-.npmrc
-
 build/
 !packages/ckeditor5-build-*/build
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://dialogue-527641002329.d.codeartifact.us-east-1.amazonaws.com/npm/distribution-readonly/


### PR DESCRIPTION
## Description 

Use local .npmrc to override global registry settings.

Update CI to use latest orbs.

## Related JIRA issues

* [DIA-59721]


[DIA-59721]: https://dialoguemd.atlassian.net/browse/DIA-59721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ